### PR TITLE
Remove quilt from apt dependencies.

### DIFF
--- a/tasks/deps.yml
+++ b/tasks/deps.yml
@@ -29,7 +29,6 @@
       - libtinfo-dev
       - net-tools
       - netbase
-      - quilt
       - tk-dev
       - zlib1g-dev
 


### PR DESCRIPTION
On Ubuntu 24.04 I get an error:

```
No package matching 'quilt' is available
```