### PR TITLE
Reverse installation order

### DIFF
--- a/tasks/python3x.yml
+++ b/tasks/python3x.yml
@@ -1,88 +1,11 @@
 ---
 
-- name: Install Python 3.1
+- name: Install Python 3.14
   ansible.builtin.include_tasks:
     file: python_generic.yml
   vars:
-    py_data: "{{ py31 }}"
-  when: python_31
-
-- name: Install Python 3.2
-  ansible.builtin.include_tasks:
-    file: python_generic.yml
-  vars:
-    py_data: "{{ py32 }}"
-  when: python_32
-
-- name: Install Python 3.3
-  ansible.builtin.include_tasks:
-    file: python_generic.yml
-  vars:
-    py_data: "{{ py33 }}"
-  when: python_33
-
-- name: Install Python 3.4
-  ansible.builtin.include_tasks:
-    file: python_generic.yml
-  vars:
-    py_data: "{{ py34 }}"
-  when: python_34
-
-- name: Install Python 3.5
-  ansible.builtin.include_tasks:
-    file: python_generic.yml
-  vars:
-    py_data: "{{ py35 }}"
-  when: python_35
-
-- name: Install Python 3.6
-  ansible.builtin.include_tasks:
-    file: python_generic.yml
-  vars:
-    py_data: "{{ py36 }}"
-  when: python_36
-
-- name: Install Python 3.7
-  ansible.builtin.include_tasks:
-    file: python_generic.yml
-  vars:
-    py_data: "{{ py37 }}"
-  when: python_37
-
-- name: Install Python 3.8
-  ansible.builtin.include_tasks:
-    file: python_generic.yml
-  vars:
-    py_data: "{{ py38 }}"
-  when: python_38
-
-- name: Install Python 3.9
-  ansible.builtin.include_tasks:
-    file: python_generic.yml
-  vars:
-    py_data: "{{ py39 }}"
-  when: python_39
-
-- name: Install Python 3.10
-  ansible.builtin.include_tasks:
-    file: python_generic.yml
-  vars:
-    py_data: "{{ py310 }}"
-  when: python_310
-
-- name: Install Python 3.11
-  ansible.builtin.include_tasks:
-    file: python_generic.yml
-  vars:
-    py_data: "{{ py311 }}"
-  when: python_311
-
-- name: Install Python 3.12
-  ansible.builtin.include_tasks:
-    file: python_generic.yml
-  vars:
-    py_data: "{{ py312 }}"
-  when: python_312
+    py_data: "{{ py314 }}"
+  when: python_314
 
 - name: Install Python 3.13
   ansible.builtin.include_tasks:
@@ -91,9 +14,86 @@
     py_data: "{{ py313 }}"
   when: python_313
 
-- name: Install Python 3.14
+- name: Install Python 3.12
   ansible.builtin.include_tasks:
     file: python_generic.yml
   vars:
-    py_data: "{{ py314 }}"
-  when: python_314
+    py_data: "{{ py312 }}"
+  when: python_312
+
+- name: Install Python 3.11
+  ansible.builtin.include_tasks:
+    file: python_generic.yml
+  vars:
+    py_data: "{{ py311 }}"
+  when: python_311
+
+- name: Install Python 3.10
+  ansible.builtin.include_tasks:
+    file: python_generic.yml
+  vars:
+    py_data: "{{ py310 }}"
+  when: python_310
+
+- name: Install Python 3.9
+  ansible.builtin.include_tasks:
+    file: python_generic.yml
+  vars:
+    py_data: "{{ py39 }}"
+  when: python_39
+
+- name: Install Python 3.8
+  ansible.builtin.include_tasks:
+    file: python_generic.yml
+  vars:
+    py_data: "{{ py38 }}"
+  when: python_38
+
+- name: Install Python 3.7
+  ansible.builtin.include_tasks:
+    file: python_generic.yml
+  vars:
+    py_data: "{{ py37 }}"
+  when: python_37
+
+- name: Install Python 3.6
+  ansible.builtin.include_tasks:
+    file: python_generic.yml
+  vars:
+    py_data: "{{ py36 }}"
+  when: python_36
+
+- name: Install Python 3.5
+  ansible.builtin.include_tasks:
+    file: python_generic.yml
+  vars:
+    py_data: "{{ py35 }}"
+  when: python_35
+
+- name: Install Python 3.4
+  ansible.builtin.include_tasks:
+    file: python_generic.yml
+  vars:
+    py_data: "{{ py34 }}"
+  when: python_34
+
+- name: Install Python 3.3
+  ansible.builtin.include_tasks:
+    file: python_generic.yml
+  vars:
+    py_data: "{{ py33 }}"
+  when: python_33
+
+- name: Install Python 3.2
+  ansible.builtin.include_tasks:
+    file: python_generic.yml
+  vars:
+    py_data: "{{ py32 }}"
+  when: python_32
+
+- name: Install Python 3.1
+  ansible.builtin.include_tasks:
+    file: python_generic.yml
+  vars:
+    py_data: "{{ py31 }}"
+  when: python_31


### PR DESCRIPTION
As usually users are interested in the newest versions, switch the order
in which they are installed: from newer to oldest releases.

So now it will install first Python 3.14, then 3.13, etc.
